### PR TITLE
Add state stores and forms for clients and services

### DIFF
--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -1,6 +1,51 @@
-import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+import {
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  TextField,
+  Button,
+} from '@mui/material';
+import { useClientStore } from '../stores/clientStore';
 
 export default function Clients() {
-  return <Typography variant="h4">Clients Page</Typography>;
+  const clients = useClientStore((state) => state.clients);
+  const addClient = useClientStore((state) => state.addClient);
+  const [name, setName] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (name.trim()) {
+      addClient(name.trim());
+      setName('');
+    }
+  };
+
+  return (
+    <div>
+      <Typography variant="h4" gutterBottom>
+        Clients
+      </Typography>
+      <List>
+        {clients.map((client) => (
+          <ListItem key={client.id}>
+            <ListItemText primary={client.name} />
+          </ListItem>
+        ))}
+      </List>
+      <form onSubmit={handleSubmit}>
+        <TextField
+          label="Client Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          size="small"
+        />
+        <Button type="submit" variant="contained" sx={{ ml: 2 }}>
+          Add Client
+        </Button>
+      </form>
+    </div>
+  );
 }
 

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,6 +1,61 @@
-import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+import {
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  TextField,
+  Button,
+} from '@mui/material';
+import { useServiceStore } from '../stores/serviceStore';
 
 export default function Services() {
-  return <Typography variant="h4">Services Page</Typography>;
+  const services = useServiceStore((state) => state.services);
+  const addService = useServiceStore((state) => state.addService);
+  const [name, setName] = useState('');
+  const [cost, setCost] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (name.trim() && cost) {
+      addService(name.trim(), Number(cost));
+      setName('');
+      setCost('');
+    }
+  };
+
+  return (
+    <div>
+      <Typography variant="h4" gutterBottom>
+        Services
+      </Typography>
+      <List>
+        {services.map((service) => (
+          <ListItem key={service.id}>
+            <ListItemText primary={`${service.name} - $${service.cost}`} />
+          </ListItem>
+        ))}
+      </List>
+      <form onSubmit={handleSubmit}>
+        <TextField
+          label="Service Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          size="small"
+        />
+        <TextField
+          label="Cost"
+          value={cost}
+          onChange={(e) => setCost(e.target.value)}
+          type="number"
+          size="small"
+          sx={{ ml: 2 }}
+        />
+        <Button type="submit" variant="contained" sx={{ ml: 2 }}>
+          Add Service
+        </Button>
+      </form>
+    </div>
+  );
 }
 

--- a/src/stores/clientStore.ts
+++ b/src/stores/clientStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import clientsData from '../data/clients.json';
+
+export interface Client {
+  id: number;
+  name: string;
+}
+
+interface ClientStore {
+  clients: Client[];
+  addClient: (name: string) => void;
+}
+
+export const useClientStore = create<ClientStore>((set) => ({
+  clients: clientsData as Client[],
+  addClient: (name: string) =>
+    set((state) => ({
+      clients: [...state.clients, { id: state.clients.length + 1, name }],
+    })),
+}));
+

--- a/src/stores/serviceStore.ts
+++ b/src/stores/serviceStore.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+import servicesData from '../data/services.json';
+
+export interface Service {
+  id: number;
+  name: string;
+  cost: number;
+}
+
+interface ServiceStore {
+  services: Service[];
+  addService: (name: string, cost: number) => void;
+}
+
+export const useServiceStore = create<ServiceStore>((set) => ({
+  services: servicesData as Service[],
+  addService: (name: string, cost: number) =>
+    set((state) => ({
+      services: [
+        ...state.services,
+        { id: state.services.length + 1, name, cost },
+      ],
+    })),
+}));
+


### PR DESCRIPTION
## Summary
- use zustand stores for clients and services initialized from JSON data
- list clients and services with forms to add new entries

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6894b4fb5e2883288dbaa0f6746dfcbc