### PR TITLE
Add engagement letter stepper to home page

### DIFF
--- a/src/components/engagement/BookkeepingServicesStep.tsx
+++ b/src/components/engagement/BookkeepingServicesStep.tsx
@@ -1,0 +1,6 @@
+import { Typography } from '@mui/material';
+
+export default function BookkeepingServicesStep() {
+  return <Typography>Bookkeeping Services Placeholder</Typography>;
+}
+

--- a/src/components/engagement/EngagementLetterStepper.tsx
+++ b/src/components/engagement/EngagementLetterStepper.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { Box, Button, Step, StepLabel, Stepper } from '@mui/material';
+import SelectClientStep from './SelectClientStep';
+import TaxServicesStep from './TaxServicesStep';
+import BookkeepingServicesStep from './BookkeepingServicesStep';
+import SummaryStep from './SummaryStep';
+
+interface EngagementLetterStepperProps {
+  onClose?: () => void;
+}
+
+const steps = [
+  { label: 'Select Client', component: <SelectClientStep /> },
+  { label: 'Tax Services', component: <TaxServicesStep /> },
+  { label: 'Bookkeeping Services', component: <BookkeepingServicesStep /> },
+  { label: 'Summary', component: <SummaryStep /> },
+];
+
+export default function EngagementLetterStepper({ onClose }: EngagementLetterStepperProps) {
+  const [activeStep, setActiveStep] = useState(0);
+
+  const handleNext = () => {
+    if (activeStep === steps.length - 1) {
+      onClose?.();
+      setActiveStep(0);
+    } else {
+      setActiveStep((prev) => prev + 1);
+    }
+  };
+
+  const handleBack = () => {
+    setActiveStep((prev) => prev - 1);
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Stepper activeStep={activeStep} sx={{ mb: 2 }}>
+        {steps.map((step) => (
+          <Step key={step.label}>
+            <StepLabel>{step.label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+      <Box sx={{ minHeight: 200, mb: 2 }}>{steps[activeStep].component}</Box>
+      <Box sx={{ display: 'flex', flexDirection: 'row', pt: 2 }}>
+        <Button color="inherit" disabled={activeStep === 0} onClick={handleBack} sx={{ mr: 1 }}>
+          Back
+        </Button>
+        <Box sx={{ flex: '1 1 auto' }} />
+        <Button onClick={handleNext}>{activeStep === steps.length - 1 ? 'Finish' : 'Next'}</Button>
+      </Box>
+    </Box>
+  );
+}
+

--- a/src/components/engagement/SelectClientStep.tsx
+++ b/src/components/engagement/SelectClientStep.tsx
@@ -1,0 +1,6 @@
+import { Typography } from '@mui/material';
+
+export default function SelectClientStep() {
+  return <Typography>Select Client Placeholder</Typography>;
+}
+

--- a/src/components/engagement/SummaryStep.tsx
+++ b/src/components/engagement/SummaryStep.tsx
@@ -1,0 +1,6 @@
+import { Typography } from '@mui/material';
+
+export default function SummaryStep() {
+  return <Typography>Summary Placeholder</Typography>;
+}
+

--- a/src/components/engagement/TaxServicesStep.tsx
+++ b/src/components/engagement/TaxServicesStep.tsx
@@ -1,0 +1,6 @@
+import { Typography } from '@mui/material';
+
+export default function TaxServicesStep() {
+  return <Typography>Tax Services Placeholder</Typography>;
+}
+

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,25 @@
-import Typography from '@mui/material/Typography';
+import { useState } from 'react';
+import { Button, Dialog, Typography } from '@mui/material';
+import EngagementLetterStepper from '../components/engagement/EngagementLetterStepper';
 
 export default function Home() {
-  return <Typography variant="h4">Home Page</Typography>;
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  return (
+    <div>
+      <Typography variant="h4" gutterBottom>
+        Home Page
+      </Typography>
+      <Button variant="contained" onClick={handleOpen} sx={{ mt: 2 }}>
+        Engagement Letter
+      </Button>
+      <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
+        <EngagementLetterStepper onClose={handleClose} />
+      </Dialog>
+    </div>
+  );
 }
 


### PR DESCRIPTION
## Summary
- Add Engagement Letter button on home page that opens a dialog
- Build stepper with placeholder steps for clients, tax services, bookkeeping services, and summary

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894bbafb7e88328a7e65f0e6b96f8f9