### PR TITLE
feat: enhance engagement letter stepper

### DIFF
--- a/src/components/engagement/BookkeepingServicesStep.tsx
+++ b/src/components/engagement/BookkeepingServicesStep.tsx
@@ -1,6 +1,36 @@
-import { Typography } from '@mui/material';
+import { Checkbox, FormControlLabel, FormGroup, Typography } from '@mui/material';
+import { useServiceStore } from '../../stores/serviceStore';
 
-export default function BookkeepingServicesStep() {
-  return <Typography>Bookkeeping Services Placeholder</Typography>;
+interface BookkeepingServicesStepProps {
+  selectedServiceIds: number[];
+  onToggleService: (id: number) => void;
 }
 
+export default function BookkeepingServicesStep({
+  selectedServiceIds,
+  onToggleService,
+}: BookkeepingServicesStepProps) {
+  const services = useServiceStore((state) =>
+    state.services.filter((s) => s.category === 'bookkeeping')
+  );
+
+  return (
+    <FormGroup>
+      <Typography variant="h6" gutterBottom>
+        Select bookkeeping services
+      </Typography>
+      {services.map((service) => (
+        <FormControlLabel
+          key={service.id}
+          control={
+            <Checkbox
+              checked={selectedServiceIds.includes(service.id)}
+              onChange={() => onToggleService(service.id)}
+            />
+          }
+          label={`${service.name} - $${service.cost}`}
+        />
+      ))}
+    </FormGroup>
+  );
+}

--- a/src/components/engagement/EngagementLetterStepper.tsx
+++ b/src/components/engagement/EngagementLetterStepper.tsx
@@ -9,15 +9,55 @@ interface EngagementLetterStepperProps {
   onClose?: () => void;
 }
 
-const steps = [
-  { label: 'Select Client', component: <SelectClientStep /> },
-  { label: 'Tax Services', component: <TaxServicesStep /> },
-  { label: 'Bookkeeping Services', component: <BookkeepingServicesStep /> },
-  { label: 'Summary', component: <SummaryStep /> },
-];
-
 export default function EngagementLetterStepper({ onClose }: EngagementLetterStepperProps) {
   const [activeStep, setActiveStep] = useState(0);
+  const [selectedClientId, setSelectedClientId] = useState<number | null>(null);
+  const [selectedServiceIds, setSelectedServiceIds] = useState<number[]>([]);
+
+  const handleToggleService = (id: number) => {
+    setSelectedServiceIds((prev) =>
+      prev.includes(id) ? prev.filter((sId) => sId !== id) : [...prev, id]
+    );
+  };
+
+  const steps = [
+    {
+      label: 'Select Client',
+      component: (
+        <SelectClientStep
+          selectedClientId={selectedClientId}
+          onSelectClient={setSelectedClientId}
+        />
+      ),
+    },
+    {
+      label: 'Tax Services',
+      component: (
+        <TaxServicesStep
+          selectedServiceIds={selectedServiceIds}
+          onToggleService={handleToggleService}
+        />
+      ),
+    },
+    {
+      label: 'Bookkeeping Services',
+      component: (
+        <BookkeepingServicesStep
+          selectedServiceIds={selectedServiceIds}
+          onToggleService={handleToggleService}
+        />
+      ),
+    },
+    {
+      label: 'Summary',
+      component: (
+        <SummaryStep
+          selectedClientId={selectedClientId}
+          selectedServiceIds={selectedServiceIds}
+        />
+      ),
+    },
+  ];
 
   const handleNext = () => {
     if (activeStep === steps.length - 1) {
@@ -47,7 +87,9 @@ export default function EngagementLetterStepper({ onClose }: EngagementLetterSte
           Back
         </Button>
         <Box sx={{ flex: '1 1 auto' }} />
-        <Button onClick={handleNext}>{activeStep === steps.length - 1 ? 'Finish' : 'Next'}</Button>
+        <Button onClick={handleNext}>
+          {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+        </Button>
       </Box>
     </Box>
   );

--- a/src/components/engagement/SelectClientStep.tsx
+++ b/src/components/engagement/SelectClientStep.tsx
@@ -1,6 +1,36 @@
-import { Typography } from '@mui/material';
+import { FormControl, FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material';
+import { useClientStore } from '../../stores/clientStore';
 
-export default function SelectClientStep() {
-  return <Typography>Select Client Placeholder</Typography>;
+interface SelectClientStepProps {
+  selectedClientId: number | null;
+  onSelectClient: (id: number) => void;
 }
 
+export default function SelectClientStep({
+  selectedClientId,
+  onSelectClient,
+}: SelectClientStepProps) {
+  const clients = useClientStore((state) => state.clients);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onSelectClient(Number(event.target.value));
+  };
+
+  return (
+    <FormControl component="fieldset">
+      <Typography variant="h6" gutterBottom>
+        Choose a client
+      </Typography>
+      <RadioGroup value={selectedClientId ?? ''} onChange={handleChange}>
+        {clients.map((client) => (
+          <FormControlLabel
+            key={client.id}
+            value={client.id}
+            control={<Radio />}
+            label={client.name}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  );
+}

--- a/src/components/engagement/SummaryStep.tsx
+++ b/src/components/engagement/SummaryStep.tsx
@@ -1,6 +1,41 @@
-import { Typography } from '@mui/material';
+import { Box, List, ListItem, ListItemText, Typography } from '@mui/material';
+import { useClientStore } from '../../stores/clientStore';
+import { useServiceStore } from '../../stores/serviceStore';
 
-export default function SummaryStep() {
-  return <Typography>Summary Placeholder</Typography>;
+interface SummaryStepProps {
+  selectedClientId: number | null;
+  selectedServiceIds: number[];
 }
 
+export default function SummaryStep({
+  selectedClientId,
+  selectedServiceIds,
+}: SummaryStepProps) {
+  const clients = useClientStore((state) => state.clients);
+  const services = useServiceStore((state) => state.services);
+
+  const client = clients.find((c) => c.id === selectedClientId);
+  const selectedServices = services.filter((s) =>
+    selectedServiceIds.includes(s.id)
+  );
+  const total = selectedServices.reduce((sum, service) => sum + service.cost, 0);
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Summary
+      </Typography>
+      <Typography variant="subtitle1">Client:</Typography>
+      <Typography gutterBottom>{client ? client.name : 'None selected'}</Typography>
+      <Typography variant="subtitle1">Services:</Typography>
+      <List>
+        {selectedServices.map((service) => (
+          <ListItem key={service.id}>
+            <ListItemText primary={`${service.name} - $${service.cost}`} />
+          </ListItem>
+        ))}
+      </List>
+      <Typography variant="h6">Total: ${total}</Typography>
+    </Box>
+  );
+}

--- a/src/components/engagement/TaxServicesStep.tsx
+++ b/src/components/engagement/TaxServicesStep.tsx
@@ -1,6 +1,36 @@
-import { Typography } from '@mui/material';
+import { Checkbox, FormControlLabel, FormGroup, Typography } from '@mui/material';
+import { useServiceStore } from '../../stores/serviceStore';
 
-export default function TaxServicesStep() {
-  return <Typography>Tax Services Placeholder</Typography>;
+interface TaxServicesStepProps {
+  selectedServiceIds: number[];
+  onToggleService: (id: number) => void;
 }
 
+export default function TaxServicesStep({
+  selectedServiceIds,
+  onToggleService,
+}: TaxServicesStepProps) {
+  const services = useServiceStore((state) =>
+    state.services.filter((s) => s.category === 'tax')
+  );
+
+  return (
+    <FormGroup>
+      <Typography variant="h6" gutterBottom>
+        Select tax services
+      </Typography>
+      {services.map((service) => (
+        <FormControlLabel
+          key={service.id}
+          control={
+            <Checkbox
+              checked={selectedServiceIds.includes(service.id)}
+              onChange={() => onToggleService(service.id)}
+            />
+          }
+          label={`${service.name} - $${service.cost}`}
+        />
+      ))}
+    </FormGroup>
+  );
+}

--- a/src/stores/serviceStore.ts
+++ b/src/stores/serviceStore.ts
@@ -5,20 +5,21 @@ export interface Service {
   id: number;
   name: string;
   cost: number;
+  category: string;
 }
 
 interface ServiceStore {
   services: Service[];
-  addService: (name: string, cost: number) => void;
+  addService: (name: string, cost: number, category?: string) => void;
 }
 
 export const useServiceStore = create<ServiceStore>((set) => ({
   services: servicesData as Service[],
-  addService: (name: string, cost: number) =>
+  addService: (name: string, cost: number, category = 'other') =>
     set((state) => ({
       services: [
         ...state.services,
-        { id: state.services.length + 1, name, cost },
+        { id: state.services.length + 1, name, cost, category },
       ],
     })),
 }));


### PR DESCRIPTION
## Summary
- add client selection, categorized service pickers, and summary to engagement letter stepper
- track service categories in store to support filtering

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6894bfee7da88328bc9c84729c3719fc