### PR TITLE
fix: prevent infinite update loop in client selection

### DIFF
--- a/src/components/engagement/EngagementLetterStepper.test.tsx
+++ b/src/components/engagement/EngagementLetterStepper.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EngagementLetterStepper from './EngagementLetterStepper';
+
+it('allows selecting a client without crashing', async () => {
+  render(<EngagementLetterStepper />);
+  const clientOption = screen.getByLabelText('Blue River Solutions');
+  await act(async () => {
+    await userEvent.click(clientOption);
+  });
+  expect(clientOption).toBeChecked();
+});

--- a/src/components/engagement/SelectClientStep.tsx
+++ b/src/components/engagement/SelectClientStep.tsx
@@ -21,11 +21,14 @@ export default function SelectClientStep({
       <Typography variant="h6" gutterBottom>
         Choose a client
       </Typography>
-      <RadioGroup value={selectedClientId ?? ''} onChange={handleChange}>
+      <RadioGroup
+        value={selectedClientId !== null ? String(selectedClientId) : ''}
+        onChange={handleChange}
+      >
         {clients.map((client) => (
           <FormControlLabel
             key={client.id}
-            value={client.id}
+            value={client.id.toString()}
             control={<Radio />}
             label={client.name}
           />


### PR DESCRIPTION
## Summary
- avoid RadioGroup value type mismatch causing repeated renders when selecting a client
- add regression test to ensure a client can be selected without crashes

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c20b25f483288996dae64e832d8a