### PR TITLE
Fix infinite re-render when advancing past client selection

### DIFF
--- a/src/components/engagement/BookkeepingServicesStep.tsx
+++ b/src/components/engagement/BookkeepingServicesStep.tsx
@@ -10,9 +10,8 @@ export default function BookkeepingServicesStep({
   selectedServiceIds,
   onToggleService,
 }: BookkeepingServicesStepProps) {
-  const services = useServiceStore((state) =>
-    state.services.filter((s) => s.category === 'bookkeeping')
-  );
+  const allServices = useServiceStore((state) => state.services);
+  const services = allServices.filter((s) => s.category === 'bookkeeping');
 
   return (
     <FormGroup>

--- a/src/components/engagement/TaxServicesStep.tsx
+++ b/src/components/engagement/TaxServicesStep.tsx
@@ -10,9 +10,8 @@ export default function TaxServicesStep({
   selectedServiceIds,
   onToggleService,
 }: TaxServicesStepProps) {
-  const services = useServiceStore((state) =>
-    state.services.filter((s) => s.category === 'tax')
-  );
+  const allServices = useServiceStore((state) => state.services);
+  const services = allServices.filter((s) => s.category === 'tax');
 
   return (
     <FormGroup>


### PR DESCRIPTION
## Summary
- Avoid infinite re-render caused by filtering services inside the Zustand selector
- Filter tax and bookkeeping services after retrieving the full list to provide stable snapshots

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c6770b6483289e11ef13a90ae4f2